### PR TITLE
Fix compilation error with empty CFLAGS of GLESv1-CM and GLESv2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,7 +121,10 @@ if not enable_gl
   if enable_glesv1_cm
     glesv1_cm_dep = dependency('glesv1_cm', required: false)
     if glesv1_cm_dep.found()
-      glesv1_cm_dep = declare_dependency(compile_args: run_command('pkg-config', '--cflags', 'glesv1_cm', check: true).stdout().strip().split(' '))
+      glesv1_cm_clags = run_command('pkg-config', '--cflags', 'glesv1_cm', check: true).stdout().strip()
+      if glesv1_cm_clags != ''
+          glesv1_cm_dep = declare_dependency(compile_args: glesv1_cm_clags.split(' '))
+      endif
       glesv1_cm_dep = declare_dependency(compile_args: ['-DGLESV1_CM_H=<GLES/gl.h>', '-DGLESV1_CM_LIB="libGLESv1_CM.so.1"'], link_args: '-ldl', dependencies: glesv1_cm_dep)
     else
       enable_glesv1_cm = false
@@ -132,7 +135,10 @@ if not enable_gl
     glesv2_dep = dependency('glesv2', required: false)
     xxd = find_program('xxd', required: false)
     if glesv2_dep.found() and xxd.found()
-      glesv2_dep = declare_dependency(compile_args: run_command('pkg-config', '--cflags', 'glesv2', check: true).stdout().strip().split(' '))
+      glesv2_clags = run_command('pkg-config', '--cflags', 'glesv2', check: true).stdout().strip()
+      if glesv2_clags != ''
+          glesv2_dep = declare_dependency(compile_args: glesv2_clags.split(' '))
+      endif
       glesv2_dep = declare_dependency(compile_args: ['-DGLESV2_H=<GLES2/gl2.h>', '-DGLESV2_LIB="libGLESv2.so.2"'], link_args: '-ldl', dependencies: glesv2_dep)
     else
       enable_glesv2 = false


### PR DESCRIPTION
When cross-compiling `yagears` on my `x86-64 host` machine for a `32-bit RISC-V Buildroot Linux target`, I encountered the following error:

```
FAILED: libyagears.a.p/gears_engine.c.o 
riscv32-buildroot-linux-gnu-gcc -Ilibyagears.a.p -I. -I../.. -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall 
-Winvalid-pch -O0 -g -D_GNU_SOURCE -DENGINE_CTOR -fPIC '' '-DGLESV2_H=<GLES2/gl2.h>' '
-DGLESV2_LIB="libGLESv2.so.2"' '' '-DGLESV1_CM_H=<GLES/gl.h>' '-DGLESV1_CM_LIB="libGLESv1_CM.so.1"' 
-MD -MQ libyagears.a.p/gears_engine.c.o -MF libyagears.a.p/gears_engine.c.o.d -o libyagears.a.p/gears_engine.c.o
-c ../../gears_engine.c
riscv32-buildroot-linux-gnu-gcc.br_real: warning: : linker input file unused because linking not done
riscv32-buildroot-linux-gnu-gcc.br_real: error: : linker input file not found: No such file or directory
riscv32-buildroot-linux-gnu-gcc.br_real: warning: : linker input file unused because linking not done
```

Upon investigation, I found the root cause to be the `''` (empty quotes) between `-DGLESV2_LIB="libGLESv2.so.2"` and `-DGLESV1_CM_H=<GLES/gl.h>`, passed to the `riscv32-buildroot-linux-gnu-gcc` command. These empty quotes were generated by the following two lines in the `meson.build:`

```
glesv1_cm_dep = declare_dependency(compile_args: run_command('pkg-config', '--cflags', 'glesv1_cm', check: true).stdout().strip().split(' '))
...
glesv2_dep = declare_dependency(compile_args: run_command('pkg-config', '--cflags', 'glesv2', check: true).stdout().strip().split(' '))
```

I realized the issue was that `pkg-config` returned empty CFLAGS for `GLESv1-CM` and `GLESv2` in my Buildroot environment. Although these libraries are installed, no CFLAGS were necessary.

To resolve this, I propose checking if the CFLAGS returned by `pkg-config` for `GLESv1_CM` and `GLESv2` are empty before passing them to the dependency variables. This will prevent unnecessary empty strings from being passed to the compiler.